### PR TITLE
Allow the url resolution to work when wagtail and puput are registere…

### DIFF
--- a/puput/managers.py
+++ b/puput/managers.py
@@ -3,6 +3,7 @@
 from django.db import models
 from django.db.models import Count
 from wagtail.wagtailcore.models import PageManager
+from .utils import strip_prefix_and_ending_slash
 
 
 class TagManager(models.Manager):
@@ -26,6 +27,6 @@ class BlogManager(PageManager):
         from .models import BlogPage
         blogs = BlogPage.objects.filter(slug=blog_path.split("/")[-1])
         for blog in blogs:
-            if blog.specific.last_url_part.strip("/") == blog_path:
+            if strip_prefix_and_ending_slash(blog.specific.last_url_part) == blog_path:
                 return blog.specific
         return

--- a/puput/urls.py
+++ b/puput/urls.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse
 
 from .feeds import BlogPageFeed
 from .views import EntryPageServe, EntryPageUpdateCommentsView
+from .utils import strip_prefix_and_ending_slash
 
 
 urlpatterns = [
@@ -83,8 +84,9 @@ def get_entry_url(entry, blog_page, root_page):
         # it is used to construct the entry url.
         # Using the stripped subdomain it allows Puput to generate the urls for
         # every sitemap level
+        blog_path = strip_prefix_and_ending_slash(blog_page.specific.last_url_part)
         return reverse('entry_page_serve_slug', kwargs={
-            'blog_path': blog_page.specific.last_url_part.strip("/"),
+            'blog_path': blog_path,
             'year': entry.date.strftime('%Y'),
             'month': entry.date.strftime('%m'),
             'day': entry.date.strftime('%d'),
@@ -100,4 +102,5 @@ def get_feeds_url(blog_page, root_page):
     if root_page == blog_page:
         return reverse('blog_page_feed')
     else:
-        return reverse('blog_page_feed_slug', kwargs={'blog_path': blog_page.specific.last_url_part.strip("/")})
+        blog_path = strip_prefix_and_ending_slash(blog_page.specific.last_url_part)
+        return reverse('blog_page_feed_slug', kwargs={'blog_path': blog_path})

--- a/puput/utils.py
+++ b/puput/utils.py
@@ -2,6 +2,7 @@
 
 from six import string_types
 from importlib import import_module
+from django.core.urlresolvers import reverse
 
 
 def import_model(path_or_callable):
@@ -16,3 +17,18 @@ def import_model(path_or_callable):
 def get_image_model_path():
     from django.conf import settings
     return getattr(settings, 'WAGTAILIMAGES_IMAGE_MODEL', 'wagtailimages.Image')
+
+
+def strip_prefix_and_ending_slash(path):
+    """
+    If puput and wagtail are registered with a prefix, it needs to be removed
+    so the 'entry_page_serve_slug' or 'blog_page_feed_slug' resolutions can work.
+    Ex, here with a dynamic (i18n_patterns()) + a static prefix :
+    urlpatterns += i18n_patterns(
+        url(r'^blah/', include('puput.urls')),
+        url(r'^blah/', include(wagtail_urls)),
+    )
+    The prefix is simply the root where Wagtail page are served.
+    https://github.com/torchbox/wagtail/blob/stable/1.8.x/wagtail/wagtailcore/urls.py#L36
+    """
+    return path.replace(reverse('wagtail_serve', args=[""]), '', 1).rstrip("/")

--- a/puput/views.py
+++ b/puput/views.py
@@ -7,6 +7,7 @@ from wagtail.wagtailcore import hooks
 
 from .comments import get_num_comments_with_disqus
 from .models import EntryPage
+from .utils import strip_prefix_and_ending_slash
 
 
 class EntryPageServe(View):
@@ -35,10 +36,10 @@ class EntryPageServe(View):
             # path_components =  ['es', 'blog', 'blog-entry']
             # with the oldest solution you'll get ['es', 'blog-entry']
             # and a 404 will be raised
-            splited_path = request.path.strip("/").split("/")
+            splited_path = strip_prefix_and_ending_slash(request.path).split("/")
             path_components = splited_path[:-4] + splited_path[-1:]
         else:
-            path_components = [request.path.strip('/').split('/')[-1]]
+            path_components = [strip_prefix_and_ending_slash(request.path).split('/')[-1]]
         page, args, kwargs = request.site.root_page.specific.route(request, path_components)
 
         for fn in hooks.get_hooks('before_serve_page'):


### PR DESCRIPTION
…d with a prefix (#82)

If puput and wagtail are registered with a prefix, it needs to be removed so the 'entry_page_serve_slug' or 'blog_page_feed_slug' resolutions can work. The prefix is simply the root where Wagtail page are served.